### PR TITLE
docs: update project acknowledgment link to roadmap.sh

### DIFF
--- a/intermediate/e-commerce-api-service/README.md
+++ b/intermediate/e-commerce-api-service/README.md
@@ -195,5 +195,5 @@ Response includes client_secret and stripe_payment_id.
 
 ## Acknowledgments
 
-- Part of the Go programming language learning roadmap projects
+- Part of the Go programming language learning [roadmap.sh](https://roadmap.sh/projects/ecommerce-api) projects
 - Created by [jaygaha](https://github.com/jaygaha)


### PR DESCRIPTION
docs: update project acknowledgment link to roadmap.sh

The acknowledgment section now includes a direct link to the roadmap.sh project page for better context and easier access to the original project source.